### PR TITLE
i2c: set 100us cap for mpu wake up latency

### DIFF
--- a/drivers/i2c/busses/i2c-omap.c
+++ b/drivers/i2c/busses/i2c-omap.c
@@ -1032,8 +1032,8 @@ omap_i2c_probe(struct platform_device *pdev)
 
 		/* calculate wakeup latency constraint for MPU */
 		if (dev->set_mpu_wkup_lat != NULL)
-			dev->latency = (1000000 * dev->fifo_size) /
-				       (1000 * speed / 8);
+			dev->latency = min(100, (1000000 * dev->fifo_size) /
+				       (1000 * speed / 8));
 	}
 
 	/* reset ASAP, clearing any IRQs */


### PR DESCRIPTION
The omap_set_mpu_wakeup_latency function overwrites the
previous value which leads to some close by i2c transactions
on different i2c busses to actually allow longer sleeps
for the fast transaction, because the slow transaction
overwrote the mpu wake up latency of the fast transaction.

This is a workaround to cap the latency for all i2c
transactions to 100us, which will always quarantee a
good response time when a i2c transaction is waiting for
completion.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jollamobile.com
