### PR TITLE
ARMv7: enable L2 cache in proc_init

### DIFF
--- a/arch/arm/mm/proc-v7.S
+++ b/arch/arm/mm/proc-v7.S
@@ -26,6 +26,10 @@
 #endif
 
 ENTRY(cpu_v7_proc_init)
+	mrc	p15, 0, r0, c1, c0, 1		@ aux ctrl register
+	orr	r0, r0, #0x2			@ L2EN
+	mcr	p15, 0, r0, c1, c0, 1		@ enable L2 cache
+
 	mov	pc, lr
 ENDPROC(cpu_v7_proc_init)
 


### PR DESCRIPTION
Since the L2 cache is disabled in proc_fin (see 56a92a31b3), it needs to be
enabled in proc_init when recovering from a kexec(). Without this, it will
remain disabled until cpuidle fixes it up during a transition, which could
be long after boot.

Signed-off-by: Richard Braakman richard.braakman@jollamobile.com
