### PR TITLE
fix definition of hsi_char_ioctl

### DIFF
--- a/drivers/hsi/clients/hsi_char.c
+++ b/drivers/hsi/clients/hsi_char.c
@@ -834,7 +834,7 @@ static unsigned int hsi_char_poll(struct file *file, poll_table *wait)
 	return ret;
 }
 
-static int hsi_char_ioctl(struct inode *inode, struct file *file,
+static long hsi_char_ioctl(struct file *file,
 					unsigned int cmd, unsigned long arg)
 {
 	struct hsi_char_channel *channel = file->private_data;


### PR DESCRIPTION
Problem: The kernel function ioctl has changed since the removal of the
Big Kernel Lock. The parameter inode has been removed and the return
type has changed. As the definition of hsi_char_ioctl still uses the old
style this will lead to problems with HSI.
Solution: This patch removes the (unneeded) inode parameter from the
function hsi_char_ioctl and changes the return parameter from int to
long.
